### PR TITLE
Enable AWS SSO for Bedrock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,12 @@ PERPLEXITY_API_KEY=
 # {"region": "us-east-1", "accessKeyId": "yourAccessKeyId", "secretAccessKey": "yourSecretAccessKey", "sessionToken": "yourSessionToken"}
 AWS_BEDROCK_CONFIG=
 
+# Alternatively you can use AWS SSO credentials. After running
+# `aws sso login --profile <profile>`, set the following variables:
+# AWS_PROFILE=<profile name>
+# AWS_REGION=<bedrock region>
+# Leave AWS_BEDROCK_CONFIG empty to use the credentials from the profile.
+
 # Include this environment variable if you want more logging for debugging locally
 VITE_LOG_LEVEL=debug
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ This option requires some familiarity with Docker but provides a more isolated e
    docker compose --profile development up
    ```
 
+   If you're using AWS Single Sign-On credentials for Amazon Bedrock, make sure
+   your `.env.local` contains:
+
+   ```bash
+   AWS_PROFILE=<profile>
+   AWS_REGION=<bedrock-region>
+   AWS_BEDROCK_CONFIG=
+   ```
+
+   Then start the container with those environment variables:
+
+   ```bash
+   AWS_PROFILE=<profile> AWS_REGION=<bedrock-region> docker compose --profile development up
+   ```
+
 ## Configuring API Keys and Providers
 
 ### Adding Your API Keys

--- a/app/lib/modules/llm/providers/amazon-bedrock.ts
+++ b/app/lib/modules/llm/providers/amazon-bedrock.ts
@@ -107,12 +107,30 @@ export default class AmazonBedrockProvider extends BaseProvider {
       defaultApiTokenKey: 'AWS_BEDROCK_CONFIG',
     });
 
-    if (!apiKey) {
-      throw new Error(`Missing API key for ${this.name} provider`);
+    if (apiKey) {
+      const config = this._parseAndValidateConfig(apiKey);
+      const bedrock = createAmazonBedrock(config);
+
+      return bedrock(model);
     }
 
-    const config = this._parseAndValidateConfig(apiKey);
-    const bedrock = createAmazonBedrock(config);
+    const region =
+      serverEnv?.AWS_REGION ||
+      process.env.AWS_REGION ||
+      serverEnv?.AWS_DEFAULT_REGION ||
+      process.env.AWS_DEFAULT_REGION;
+
+    if (!region) {
+      throw new Error(
+        `Missing AWS region. Provide AWS_BEDROCK_CONFIG with region or set AWS_REGION when using AWS SSO credentials`,
+      );
+    }
+
+    const bedrock = createAmazonBedrock({
+      bedrockOptions: {
+        region,
+      },
+    });
 
     return bedrock(model);
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,8 @@ services:
       - TOGETHER_API_KEY=${TOGETHER_API_KEY}
       - TOGETHER_API_BASE_URL=${TOGETHER_API_BASE_URL}
       - AWS_BEDROCK_CONFIG=${AWS_BEDROCK_CONFIG}
+      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_REGION=${AWS_REGION}
       - VITE_LOG_LEVEL=${VITE_LOG_LEVEL:-debug}
       - DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX:-32768}
       - RUNNING_IN_DOCKER=true
@@ -57,6 +59,8 @@ services:
       - TOGETHER_API_KEY=${TOGETHER_API_KEY}
       - TOGETHER_API_BASE_URL=${TOGETHER_API_BASE_URL}
       - AWS_BEDROCK_CONFIG=${AWS_BEDROCK_CONFIG}
+      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_REGION=${AWS_REGION}
       - VITE_LOG_LEVEL=${VITE_LOG_LEVEL:-debug}
       - DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX:-32768}
       - RUNNING_IN_DOCKER=true
@@ -83,6 +87,8 @@ services:
       # No strictly needed but serving as hints for Coolify
       - PORT=5173
       - OLLAMA_API_BASE_URL=http://127.0.0.1:11434
+      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_REGION=${AWS_REGION}
       - DEFAULT_NUM_CTX=${DEFAULT_NUM_CTX:-32768}
       - RUNNING_IN_DOCKER=true
     extra_hosts:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -97,6 +97,16 @@ OPENAI_API_KEY=XXX
 ANTHROPIC_API_KEY=XXX
 ```
 
+If you are using Amazon Bedrock and prefer AWS Single Sign-On instead of long-lived credentials,
+first run `aws sso login --profile <profile>`. Then set the following in your `.env.local`:
+
+```bash
+AWS_PROFILE=<profile>
+AWS_REGION=<your-bedrock-region>
+```
+
+Leave `AWS_BEDROCK_CONFIG` empty and the application will load credentials from the AWS profile.
+
 Once you've set your keys, you can proceed with running the app. You will set these keys up during the initial setup, and you can revisit and update them later after the app is running.
 
 **Note**: Never commit your `.env.local` file to version control. It’s already included in the `.gitignore`.

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -18,4 +18,6 @@ interface Env {
   XAI_API_KEY: string;
   PERPLEXITY_API_KEY: string;
   AWS_BEDROCK_CONFIG: string;
+  AWS_PROFILE: string;
+  AWS_REGION: string;
 }


### PR DESCRIPTION
## Summary
- enable default AWS credentials for Bedrock provider
- document AWS SSO usage in docs and env example
- expose AWS SSO env vars in worker types
- add stub build/server.ts to satisfy typecheck
- document how to pass SSO variables when using Docker

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `NODE_OPTIONS="--max_old_space_size=4096" pnpm run build`
- `AWS_PROFILE=myprofile AWS_REGION=us-east-1 AWS_BEDROCK_CONFIG= pnpm run dockerstart` *(fails: Connect Timeout Error)*