### PR TITLE
Fix Bedrock SSO credential check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,13 @@ PERPLEXITY_API_KEY=
 # {"region": "us-east-1", "accessKeyId": "yourAccessKeyId", "secretAccessKey": "yourSecretAccessKey", "sessionToken": "yourSessionToken"}
 AWS_BEDROCK_CONFIG=
 
+# Alternatively you can use AWS SSO credentials. After running
+# `aws sso login --profile <profile>`, set the following variables:
+# AWS_PROFILE=<profile name>
+# AWS_REGION=<bedrock region>
+# AWS_SDK_LOAD_CONFIG=1
+# Leave AWS_BEDROCK_CONFIG empty to use the credentials from the profile.
+
 # Include this environment variable if you want more logging for debugging locally
 VITE_LOG_LEVEL=debug
 

--- a/app/lib/modules/llm/providers/amazon-bedrock.ts
+++ b/app/lib/modules/llm/providers/amazon-bedrock.ts
@@ -107,12 +107,30 @@ export default class AmazonBedrockProvider extends BaseProvider {
       defaultApiTokenKey: 'AWS_BEDROCK_CONFIG',
     });
 
-    if (!apiKey) {
-      throw new Error(`Missing API key for ${this.name} provider`);
+    if (apiKey) {
+      const config = this._parseAndValidateConfig(apiKey);
+      const bedrock = createAmazonBedrock(config);
+
+      return bedrock(model);
     }
 
-    const config = this._parseAndValidateConfig(apiKey);
-    const bedrock = createAmazonBedrock(config);
+    const region =
+      serverEnv?.AWS_REGION ||
+      process.env.AWS_REGION ||
+      serverEnv?.AWS_DEFAULT_REGION ||
+      process.env.AWS_DEFAULT_REGION;
+
+    if (!region) {
+      throw new Error(
+        `Missing AWS region. Provide AWS_BEDROCK_CONFIG with region or set AWS_REGION when using AWS SSO credentials`,
+      );
+    }
+
+    const bedrock = createAmazonBedrock({
+      bedrockOptions: {
+        region,
+      },
+    });
 
     return bedrock(model);
   }

--- a/app/routes/api.check-env-key.ts
+++ b/app/routes/api.check-env-key.ts
@@ -18,6 +18,7 @@ export const loader: LoaderFunction = async ({ context, request }) => {
   }
 
   const envVarName = providerInstance.config.apiTokenKey;
+  const env = context?.cloudflare?.env as Record<string, any>;
 
   // Get API keys from cookie
   const cookieHeader = request.headers.get('Cookie');
@@ -30,12 +31,33 @@ export const loader: LoaderFunction = async ({ context, request }) => {
    * 3. Process environment variables (from .env.local)
    * 4. LLMManager environment variables
    */
-  const isSet = !!(
-    apiKeys?.[provider] ||
-    (context?.cloudflare?.env as Record<string, any>)?.[envVarName] ||
-    process.env[envVarName] ||
-    llmManager.env[envVarName]
-  );
+  let isSet = !!(apiKeys?.[provider] || env?.[envVarName] || process.env[envVarName] || llmManager.env[envVarName]);
+
+  /*
+   * Amazon Bedrock can use AWS SSO or container credentials when
+   * AWS_BEDROCK_CONFIG is not provided, so check for common AWS
+   * credential environment variables as a fallback.
+   */
+  if (!isSet && provider === 'AmazonBedrock') {
+    const region =
+      env?.AWS_REGION || env?.AWS_DEFAULT_REGION || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
+
+    const hasAwsCreds =
+      env?.AWS_ACCESS_KEY_ID ||
+      process.env.AWS_ACCESS_KEY_ID ||
+      env?.AWS_PROFILE ||
+      process.env.AWS_PROFILE ||
+      env?.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ||
+      process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ||
+      env?.AWS_WEB_IDENTITY_TOKEN_FILE ||
+      process.env.AWS_WEB_IDENTITY_TOKEN_FILE ||
+      env?.AWS_ROLE_ARN ||
+      process.env.AWS_ROLE_ARN;
+
+    if (region && hasAwsCreds) {
+      isSet = true;
+    }
+  }
 
   return Response.json({ isSet });
 };

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -97,6 +97,19 @@ OPENAI_API_KEY=XXX
 ANTHROPIC_API_KEY=XXX
 ```
 
+If you are using Amazon Bedrock and prefer AWS Single Sign-On instead of long-lived credentials,
+first run `aws sso login --profile <profile>`. Then set the following in your `.env.local`:
+
+```bash
+AWS_PROFILE=<profile>
+AWS_REGION=<your-bedrock-region>
+AWS_SDK_LOAD_CONFIG=1
+```
+
+Leave `AWS_BEDROCK_CONFIG` empty and the application will load credentials from the AWS profile.
+
+Credentials from IAM roles (such as those provided in EKS or ECS) are also detected automatically.
+
 Once you've set your keys, you can proceed with running the app. You will set these keys up during the initial setup, and you can revisit and update them later after the app is running.
 
 **Note**: Never commit your `.env.local` file to version control. It’s already included in the `.gitignore`.

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -18,4 +18,7 @@ interface Env {
   XAI_API_KEY: string;
   PERPLEXITY_API_KEY: string;
   AWS_BEDROCK_CONFIG: string;
+  AWS_PROFILE: string;
+  AWS_REGION: string;
+  AWS_SDK_LOAD_CONFIG: string;
 }


### PR DESCRIPTION
## Summary
- detect AWS SSO/role credentials for Amazon Bedrock
- document AWS_SDK_LOAD_CONFIG and container role support
- expose AWS_SDK_LOAD_CONFIG in worker config type

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `NODE_OPTIONS="--max_old_space_size=4096" pnpm run build`
- `pnpm run dockerstart` *(fails: connect EHOSTUNREACH)*